### PR TITLE
Update ece-install-trail

### DIFF
--- a/usr/lib/check_mk_agent/local/ece-install-trail
+++ b/usr/lib/check_mk_agent/local/ece-install-trail
@@ -11,8 +11,8 @@
 # trail_presentation_port=1234
 # trail_editorial_port=1235
 
-critical=400
-warning=250
+critical=900
+warning=700
 
 function check_trail() {
   for el in /var/lib/ece-install/*.trail ; do


### PR DESCRIPTION
check_mk checks for the number of active TCP connections is too low so, it has been increased.
